### PR TITLE
DHE-DSS & RC4 on Fedora (and other non-RHEL distros) with gnutls

### DIFF
--- a/gnutls/Interoperability/TLSv1-2-with-NSS/runtest.sh
+++ b/gnutls/Interoperability/TLSv1-2-with-NSS/runtest.sh
@@ -32,6 +32,7 @@
 PACKAGE="gnutls"
 PACKAGES="openssl gnutls nss"
 
+GNUTLS_PRIO="NORMAL:+ARCFOUR-128:+DHE-DSS:+SIGN-DSA-SHA1:+SIGN-DSA-SHA224:+SIGN-DSA-SHA256"
 SERVER_UTIL="/usr/lib/nss/unsupported-tools/selfserv"
 CLIENT_UTIL="/usr/lib/nss/unsupported-tools/tstclnt"
 [ -f /usr/lib64/nss/unsupported-tools/selfserv ] && SERVER_UTIL="/usr/lib64/nss/unsupported-tools/selfserv"
@@ -391,7 +392,7 @@ rlJournalStart
             options=(gnutls-serv --http -p 4433)
             options+=(--x509keyfile ${C_KEY[$j]})
             options+=(--x509certfile "<(cat ${C_CERT[$j]} ${C_SUBCA[$j]})")
-            options+=(--priority NORMAL:+VERS-TLS1.2)
+            options+=(--priority ${GNUTLS_PRIO}:+VERS-TLS1.2)
             options+=(">server.log" "2>server.err" "&")
             rlRun "${options[*]}"
             gnutls_pid=$!
@@ -451,9 +452,9 @@ rlJournalStart
             options+=(--x509cafile $(x509Cert ca))
             options+=(-p 4433 localhost)
             if [[ $prot == "tls1_2" ]]; then
-                options+=(--priority NORMAL:+VERS-TLS1.2)
+                options+=(--priority ${GNUTLS_PRIO}:+VERS-TLS1.2)
             else
-                options+=(--priority NORMAL:-VERS-TLS1.2)
+                options+=(--priority ${GNUTLS_PRIO}:-VERS-TLS1.2)
             fi
             rlRun -s "expect gnutls-client.expect ${options[*]}"
             rlAssertGrep "GET / HTTP/1.0" $rlRun_LOG
@@ -484,7 +485,7 @@ rlJournalStart
 
             rlLogInfo "Test proper"
             options=(--http -p 4433)
-            options+=(--priority NORMAL:+VERS-TLS1.2)
+            options+=(--priority ${GNUTLS_PRIO}:+VERS-TLS1.2)
             options+=(--x509keyfile ${C_KEY[$j]})
             options+=(--x509certfile '<(cat ${C_CERT[$j]} ${C_SUBCA[$j]})')
             options+=(--x509cafile '<(cat $(x509Cert ca) ${C_SUBCA[$j]})')
@@ -562,9 +563,9 @@ rlJournalStart
             options+=(--x509certfile ${C_CLNT_CERT[$j]})
             options+=(--x509keyfile ${C_CLNT_KEY[$j]})
             if [[ $prot == "tls1_2" ]]; then
-                options+=(--priority NORMAL:+VERS-TLS1.2)
+                options+=(--priority ${GNUTLS_PRIO}:+VERS-TLS1.2)
             else
-                options+=(--priority NORMAL:-VERS-TLS1.2)
+                options+=(--priority ${GNUTLS_PRIO}:-VERS-TLS1.2)
             fi
             rlRun -s "expect gnutls-client.expect ${options[*]}"
             rlAssertGrep "GET / HTTP/1.0" $rlRun_LOG

--- a/gnutls/Interoperability/TLSv1-2-with-OpenSSL/runtest.sh
+++ b/gnutls/Interoperability/TLSv1-2-with-OpenSSL/runtest.sh
@@ -31,6 +31,7 @@
 
 PACKAGE="gnutls"
 PACKAGES="openssl gnutls"
+GNUTLS_PRIO="NORMAL:+ARCFOUR-128:+DHE-DSS:+SIGN-DSA-SHA1:+SIGN-DSA-SHA224:+SIGN-DSA-SHA256"
 
 rlJournalStart
     rlPhaseStartSetup
@@ -379,10 +380,10 @@ rlJournalStart
             options=(gnutls-cli)
             options+=(--x509cafile $(x509Cert ca))
             if [[ $prot == tls1_2 ]]; then
-                options+=(--priority NORMAL:+VERS-TLS1.2)
+                options+=(--priority ${GNUTLS_PRIO}:+VERS-TLS1.2)
             fi
             if [[ $prot == tls1_1 ]]; then
-                options+=(--priority NORMAL:-VERS-TLS1.2)
+                options+=(--priority ${GNUTLS_PRIO}:-VERS-TLS1.2)
             fi
             options+=(-p 4433 localhost)
             rlRun -s "expect gnutls-client.expect ${options[*]}"
@@ -403,7 +404,7 @@ rlJournalStart
 
         rlPhaseStartTest "GnuTLS server OpenSSL client ${C_NAME[$j]} cipher $prot protocol"
             options=(gnutls-serv --echo -p 4433)
-            options+=(--priority NORMAL:+VERS-TLS1.2)
+            options+=(--priority ${GNUTLS_PRIO}:+VERS-TLS1.2)
             options+=(--x509keyfile ${C_KEY[$j]})
             options+=(--x509certfile "<(cat ${C_CERT[$j]} ${C_SUBCA[$j]})")
             options+=(">server.log" "2>server.err" "&")
@@ -451,10 +452,10 @@ rlJournalStart
             options+=(--x509keyfile ${C_CLNT_KEY[$j]})
             options+=(--x509certfile ${C_CLNT_CERT[$j]})
             if [[ $prot == tls1_2 ]]; then
-                options+=(--priority NORMAL:+VERS-TLS1.2)
+                options+=(--priority ${GNUTLS_PRIO}:+VERS-TLS1.2)
             fi
             if [[ $prot == tls1_1 ]]; then
-                options+=(--priority NORMAL:-VERS-TLS1.2)
+                options+=(--priority ${GNUTLS_PRIO}:-VERS-TLS1.2)
             fi
             options+=(-p 4433 localhost)
             rlRun -s "expect gnutls-client.expect ${options[*]}"
@@ -475,7 +476,7 @@ rlJournalStart
 
         rlPhaseStartTest "GnuTLS server OpenSSL client ${C_NAME[$j]} cipher $prot protocol client cert"
             options=(gnutls-serv --echo -p 4433)
-            options+=(--priority NORMAL:+VERS-TLS1.2)
+            options+=(--priority ${GNUTLS_PRIO}:+VERS-TLS1.2)
             options+=(--x509keyfile ${C_KEY[$j]})
             options+=(--x509certfile "<(cat ${C_CERT[$j]} ${C_SUBCA[$j]})")
             options+=(--x509cafile "<(cat $(x509Cert ca) ${C_SUBCA[$j]})")

--- a/openssl/Interoperability/CC-openssl-with-gnutls/runtest.sh
+++ b/openssl/Interoperability/CC-openssl-with-gnutls/runtest.sh
@@ -31,6 +31,7 @@
 
 PACKAGE="openssl"
 PACKAGES="nss gnutls"
+GNUTLS_PRIO="NORMAL:+ARCFOUR-128:+DHE-DSS:+SIGN-DSA-SHA1:+SIGN-DSA-SHA224:+SIGN-DSA-SHA256"
 
 rlJournalStart
     rlPhaseStartSetup
@@ -544,7 +545,9 @@ rlJournalStart
             options=(gnutls-cli)
             options+=(--x509cafile $(x509Cert ca))
             if [[ $prot == tls1_1 ]]; then
-                options+=(--priority NORMAL:-VERS-TLS1.2)
+                options+=(--priority ${GNUTLS_PRIO}:-VERS-TLS1.2)
+            else
+                options+=(--priority ${GNUTLS_PRIO})
             fi
             options+=(-p 4433 localhost)
             rlRun -s "expect gnutls-client.expect ${options[*]}"
@@ -562,6 +565,7 @@ rlJournalStart
         rlPhaseStartTest "GnuTLS server OpenSSL client ${C_NAME[$j]} cipher $prot protocol"
             rlRun "gnutls-serv --echo -p 4433 --x509keyfile ${C_KEY[$j]} \
                    --x509certfile <(cat ${C_CERT[$j]} ${C_SUBCA[$j]}) \
+                   --priority ${GNUTLS_PRIO} \
                    >server.log 2>server.err &"
             gnutls_pid=$!
             rlRun "rlWaitForSocket 4433 -p $gnutls_pid"
@@ -601,7 +605,9 @@ rlJournalStart
             options+=(--x509keyfile ${C_CLNT_KEY[$j]})
             options+=(--x509certfile ${C_CLNT_CERT[$j]})
             if [[ $prot == tls1_1 ]]; then
-                options+=(--priority NORMAL:-VERS-TLS1.2)
+                options+=(--priority ${GNUTLS_PRIO}:-VERS-TLS1.2)
+            else
+                options+=(--priority ${GNUTLS_PRIO})
             fi
             options+=(-p 4433 localhost)
             rlRun -s "expect gnutls-client.expect ${options[*]}"
@@ -621,6 +627,7 @@ rlJournalStart
                    --x509certfile <(cat ${C_CERT[$j]} ${C_SUBCA[$j]}) \
                    --x509cafile <(cat $(x509Cert ca) ${C_SUBCA[$j]}) \
                    --require-client-cert --verify-client-cert \
+                   --priority ${GNUTLS_PRIO} \
                    >server.log 2>server.err &"
             gnutls_pid=$!
             rlRun "rlWaitForSocket 4433 -p $gnutls_pid"


### PR DESCRIPTION
Summary:

- All ciphersuites using DHE-DSS are skipped on non-RHEL distros
- RC4 is now explicitly enabled

These changes should (and according to the Travis they even do) ensure test suite compatibility with Fedora.