### PR TITLE
Fix several issues in CI/tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ env:
         - COMP=nss OS_TYPE=centos OS_VERSION=5
         - COMP=nss OS_TYPE=centos OS_VERSION=6
         - COMP=nss OS_TYPE=centos OS_VERSION=7
-        - COMP=nss OS_TYPE=fedora OS_VERSION=24
+        - COMP=nss OS_TYPE=fedora OS_VERSION=24 TEST_GLOB='@(renego*)'
+        - COMP=nss OS_TYPE=fedora OS_VERSION=24 TEST_GLOB='!(renego*)'
         # gnutls tests
         - COMP=gnutls OS_TYPE=centos OS_VERSION=5
         - COMP=gnutls OS_TYPE=centos OS_VERSION=6
@@ -25,4 +26,4 @@ before_install:
     - sudo docker pull ${OS_TYPE}:${OS_VERSION}
 
 script:
-    - ./scripts/test-setup.sh ${OS_TYPE} ${OS_VERSION} ${COMP}
+    - ./scripts/test-setup.sh ${OS_TYPE} ${OS_VERSION} ${COMP} "${TEST_GLOB}"

--- a/gnutls/Interoperability/TLSv1-2-with-NSS/nss-client.expect
+++ b/gnutls/Interoperability/TLSv1-2-with-NSS/nss-client.expect
@@ -4,9 +4,18 @@ spawn /bin/sh -c "$argv"
 expect {
     "Enter Password" { send "RedHatEnterpriseLinux6.6\r"; exp_continue }
     eof { }
-    "subject DN" { send "GET / HTTP/1.0\r\r"; 
-                   expect -timeout 5 "HTTP/1.0 200 OK" { close; exit 0}
-                   close; exit 1}
+    "subject DN" {
+        send "GET / HTTP/1.0\r\r";
+        expect -timeout 5 "HTTP/1.0 200 OK" {
+            expect -re ".+" {
+                close;
+                exit 0;
+            }
+        }
+
+        close;
+        exit 1;
+    }
 }
 set info [wait]
 #puts "Return from wait: $info"

--- a/gnutls/Interoperability/TLSv1-2-with-OpenSSL/gnutls-client.expect
+++ b/gnutls/Interoperability/TLSv1-2-with-OpenSSL/gnutls-client.expect
@@ -6,6 +6,7 @@ expect {
         send "client hello\r"
         expect {
             "server hello" {
+                    sleep 1
                     close
                     exit 0
             }

--- a/gnutls/Interoperability/TLSv1-2-with-OpenSSL/openssl-client.expect
+++ b/gnutls/Interoperability/TLSv1-2-with-OpenSSL/openssl-client.expect
@@ -6,8 +6,10 @@ expect {
         send "client hello\r"
         expect "client hello" {
             expect "client hello" {
-                close
-                exit 0
+                expect -re ".+" {
+                    close
+                    exit 0
+                }
             }
         }
     }

--- a/gnutls/Interoperability/renegotiation-with-NSS/runtest.sh
+++ b/gnutls/Interoperability/renegotiation-with-NSS/runtest.sh
@@ -86,3 +86,4 @@ rlJournalStart
     rlPhaseEnd
 rlJournalPrintText
 rlJournalEnd
+rlGetTestState

--- a/gnutls/Interoperability/renegotiation-with-OpenSSL/runtest.sh
+++ b/gnutls/Interoperability/renegotiation-with-OpenSSL/runtest.sh
@@ -72,3 +72,4 @@ rlJournalStart
     rlPhaseEnd
 rlJournalPrintText
 rlJournalEnd
+rlGetTestState

--- a/gnutls/Interoperability/resumption-with-NSS/runtest.sh
+++ b/gnutls/Interoperability/resumption-with-NSS/runtest.sh
@@ -91,3 +91,4 @@ rlJournalStart
     rlPhaseEnd
 rlJournalPrintText
 rlJournalEnd
+rlGetTestState

--- a/gnutls/Interoperability/resumption-with-OpenSSL/runtest.sh
+++ b/gnutls/Interoperability/resumption-with-OpenSSL/runtest.sh
@@ -77,3 +77,4 @@ rlJournalStart
     rlPhaseEnd
 rlJournalPrintText
 rlJournalEnd
+rlGetTestState

--- a/gnutls/Interoperability/softhsm-integration/Makefile
+++ b/gnutls/Interoperability/softhsm-integration/Makefile
@@ -57,5 +57,5 @@ $(METADATA): Makefile
 	@echo "License:         GPLv2+" >> $(METADATA)
 	@echo "Confidential:    yes" >> $(METADATA)
 	@echo "Destructive:     no" >> $(METADATA)
-	@echo "Releases:        -RHEL4 -RHELClient5 -RHELServer5" >> $(METADATA)
+	@echo "Releases:        -RHEL4 -RHELClient5 -RHELServer5 -RHEL6 -RHEL7" >> $(METADATA)
 

--- a/gnutls/Interoperability/softhsm-integration/runtest.sh
+++ b/gnutls/Interoperability/softhsm-integration/runtest.sh
@@ -80,3 +80,4 @@ _EOF
     rlPhaseEnd
 rlJournalPrintText
 rlJournalEnd
+rlGetTestState

--- a/nss/Interoperability/CC-nss-with-gnutls/gnutls-client.expect
+++ b/nss/Interoperability/CC-nss-with-gnutls/gnutls-client.expect
@@ -6,8 +6,9 @@ expect {
         send "GET / HTTP/1.0\r\r";
         expect {
             "Generic Web Server" {
-                    close
-                    exit 0
+                sleep 1
+                close
+                exit 0
             }
         }
     }

--- a/nss/Interoperability/CC-nss-with-gnutls/nss-client.expect
+++ b/nss/Interoperability/CC-nss-with-gnutls/nss-client.expect
@@ -4,9 +4,18 @@ spawn /bin/sh -c "$argv"
 expect {
     "Enter Password" { send "RedHatEnterpriseLinux6.6\r"; exp_continue }
     eof { }
-    "subject DN" { send "GET / HTTP/1.0\r\r"; 
-                   expect -timeout 5 "HTTP/1.0 200 OK" { close; exit 0}
-                   close; exit 1}
+    "subject DN" {
+        send "GET / HTTP/1.0\r\r";
+        expect -timeout 5 "HTTP/1.0 200 OK" {
+            expect -re ".+" {
+                close;
+                exit 0;
+            }
+        }
+
+        close;
+        exit 1;
+    }
 }
 set info [wait]
 #puts "Return from wait: $info"

--- a/nss/Interoperability/CC-nss-with-openssl/openssl-client.expect
+++ b/nss/Interoperability/CC-nss-with-openssl/openssl-client.expect
@@ -5,8 +5,10 @@ expect {
     "Verify return code: 0 " {
         send "GET / HTTP/1.0\r\r"
         expect "Server: Generic Web Server" {
-            close
-            exit 0
+            expect -re ".+" {
+                close
+                exit 0
+            }
         }
     }
 }

--- a/nss/Interoperability/renego-and-resumption-NSS-with-OpenSSL/nss-client.expect
+++ b/nss/Interoperability/renego-and-resumption-NSS-with-OpenSSL/nss-client.expect
@@ -4,9 +4,14 @@ spawn /bin/sh -c "$argv"
 expect {
     "Enter Password" { send "RedHatEnterpriseLinux6.6\r"; exp_continue }
     eof { }
-    "subject DN" { expect "subject DN" { send "GET / HTTP/1.0\r\r";
-                                         expect -timeout 5 "Verify return code";
-                                         close}}
+    "subject DN" {
+        expect "subject DN" {
+            send "GET / HTTP/1.0\r\r";
+            expect -timeout 5 "Verify return code";
+            sleep 1;
+            close;
+        }
+    }
 }
 set info [wait]
 #puts "Return from wait: $info"

--- a/nss/Interoperability/renego-and-resumption-NSS-with-OpenSSL/runtest.sh
+++ b/nss/Interoperability/renego-and-resumption-NSS-with-OpenSSL/runtest.sh
@@ -599,3 +599,4 @@ rlJournalStart
     rlPhaseEnd
 rlJournalPrintText
 rlJournalEnd
+rlGetTestState

--- a/scripts/test-runner.sh
+++ b/scripts/test-runner.sh
@@ -26,10 +26,17 @@ function keep_alive() {
 # $2 - glob pattern
 function test_name_relevancy() {
     # See: http://wiki.bash-hackers.org/syntax/pattern#extended_pattern_language
+    # Save the original state
+    shopt -q extglob
+    local STATE=$?
+    # Enable extglob
     shopt -s extglob
     [[ $1 == $2 ]]
     local RES=$?
-    shopt -u extglob
+    # If the extension was originally disabled, disable it
+    if [[ $STATE -ne 0 ]]; then
+        shopt -u extglob
+    fi
 
     return $RES
 }

--- a/scripts/test-runner.sh
+++ b/scripts/test-runner.sh
@@ -21,6 +21,19 @@ function keep_alive() {
     done
 }
 
+# Compare test name with glob expression using extended glob patterns
+# $1 - test name
+# $2 - glob pattern
+function test_name_relevancy() {
+    # See: http://wiki.bash-hackers.org/syntax/pattern#extended_pattern_language
+    shopt -s extglob
+    [[ $1 == $2 ]]
+    local RES=$?
+    shopt -u extglob
+
+    return $RES
+}
+
 set +x
 
 if [[ $# < 3 ]]; then
@@ -31,6 +44,7 @@ fi
 OS_TYPE="$1"
 OS_VERSION="$2"
 COMPONENT="$3"
+TEST_GLOB="$4"
 if [[ $OS_TYPE == "fedora" ]]; then
     PKG_MAN="dnf"
 else
@@ -72,12 +86,26 @@ do
     SKIP=0
 
     echo "Running test: $test"
+
+    # Check if glob pattern is set
+    if [[ ! -z "$TEST_GLOB" ]]; then
+        # If so, check if it matches current test name
+        TEST_NAME="$(basename $(dirname "$test"))"
+        if ! test_name_relevancy "$TEST_NAME" "$TEST_GLOB"; then
+            echo "Test '$TEST_NAME' excluded by given glob expression: $TEST_GLOB"
+            SKIPPED+=("$test")
+            continue
+        fi
+    fi
+
+    # Makefile is necessary for test execution
     pushd "$(dirname "$test")"
     if [[ ! -f Makefile ]]; then
         echo >&2 "Missing Makefile"
         EC=1
         SKIP=1
     fi
+
     if [[ $SKIP -eq 0 ]]; then
         # Check relevancy
         if relevancy.awk -v os_type=$OS_TYPE -v os_ver=$OS_VERSION Makefile; then

--- a/scripts/test-setup.sh
+++ b/scripts/test-setup.sh
@@ -12,6 +12,23 @@ CONT_NAME="${OS_TYPE}-${OS_VERSION}-${COMPONENT}"
 CERTGEN_REPO="https://github.com/redhat-qe-security/certgen"
 CERTGEN_PATH="openssl/Library/certgen"
 
+# Test sanity check
+# Check if all tests have rlGetTestState at their end
+FAILED_CHECKS=0
+FAILED_NAMES=()
+while read file; do
+    if ! grep -Pzoq "rlGetTestState.*$" "$file"; then
+        FAILED_CHECKS=$(($FAILED_CHECKS+1))
+        FAILED_NAMES+=("$file")
+    fi
+done <<< "$(find . -type f -name "runtest.sh")"
+
+if [[ $FAILED_CHECKS -gt 0 ]]; then
+    echo "Following tests are missing rlGetTestState command:"
+    printf '%s\n' "${FAILED_NAMES[@]}"
+    exit 1
+fi
+
 # Prepare necessary libraries
 # openssl/certgen:
 TMP_DIR="$(mktemp -d tmp.XXXXX)"

--- a/scripts/test-setup.sh
+++ b/scripts/test-setup.sh
@@ -8,6 +8,7 @@ fi
 OS_TYPE="$1"
 OS_VERSION="$2"
 COMPONENT="$3"
+TEST_GLOB="$4"
 CONT_NAME="${OS_TYPE}-${OS_VERSION}-${COMPONENT}"
 CERTGEN_REPO="https://github.com/redhat-qe-security/certgen"
 CERTGEN_PATH="openssl/Library/certgen"
@@ -17,7 +18,7 @@ CERTGEN_PATH="openssl/Library/certgen"
 FAILED_CHECKS=0
 FAILED_NAMES=()
 while read file; do
-    if ! grep -Pzoq "rlGetTestState.*$" "$file"; then
+    if ! grep -Pzoq "rlGetTestState[[:space:]]*$" "$file"; then
         FAILED_CHECKS=$(($FAILED_CHECKS+1))
         FAILED_NAMES+=("$file")
     fi
@@ -50,4 +51,4 @@ sudo docker run --rm --name "$CONT_NAME" \
                 -v $PWD:/workspace:rw \
                 ${OS_TYPE}:${OS_VERSION} \
                 /bin/bash -c \
-                "bash -x $RUNNER $OS_TYPE $OS_VERSION $COMPONENT"
+                "bash -x $RUNNER $OS_TYPE $OS_VERSION $COMPONENT '$TEST_GLOB'"


### PR DESCRIPTION
1) During the review of test results I found out that several test are missing `rlGetTestState` command at their ends, which results in false-positives (as the default script return code is zero). This should be fixed in commit 75e6128. I also added a simple sanity check, which ensures that all non-library test scripts (`runtest.sh`) contain the mentioned `rlGetTestState`. If a script with missing `rlGetTestState` is encountered, the job is immediately aborted (31dcda2).

2) After extending the nss test suite, we managed to hit both Travis' limits - job length, which is 50 minutes, and log size, which is 4 MB. Commit ce96c52 implements a simple solution, which allows specifying an environment by an extended bash file glob expression ([extglob](https://www.gnu.org/software/bash/manual/html_node/Pattern-Matching.html)). I already tested it on the aforementioned nss test suite and it works pretty well.

3) Last issue concerns the gnutls/softhsm-integration test, which has wrong metadata in its Makefile. This test is unsupported on RHEL/CentOS 6 and has an already fixed bug on RHEL/CentOS 7.2 - in this case we have to simply wait for a docker image for CentOS 7.3. I disabled this test on both RHEL/CentOS 6 and RHEL/CentOS 7 and will create an issue to re-enable it on CentOS 7 once the appropriate docker image is released.