### PR TITLE
nss/renego-and-resumption-NSS-with-OpenSSL - test extension

### DIFF
--- a/nss/Interoperability/renego-and-resumption-NSS-with-OpenSSL/Makefile
+++ b/nss/Interoperability/renego-and-resumption-NSS-with-OpenSSL/Makefile
@@ -29,7 +29,8 @@ export TESTVERSION=1.0
 
 BUILT_FILES=
 
-FILES=$(METADATA) runtest.sh Makefile PURPOSE nss-client.expect
+FILES=$(METADATA) runtest.sh Makefile PURPOSE nss-client.expect \
+                  nss-server.expect openssl-client.expect
 
 .PHONY: all install download clean
 

--- a/nss/Interoperability/renego-and-resumption-NSS-with-OpenSSL/nss-server.expect
+++ b/nss/Interoperability/renego-and-resumption-NSS-with-OpenSSL/nss-server.expect
@@ -1,0 +1,12 @@
+#!/usr/bin/expect
+set timeout 15
+spawn /bin/sh -c "$argv"
+expect {
+    "Enter Password" { send "RedHatEnterpriseLinux6.6\r"; exp_continue }
+    eof { }
+    "client hello" { send "server hello\r";
+                   close}
+}
+set info [wait]
+#puts "Return from wait: $info"
+exit [lindex $info 3]

--- a/nss/Interoperability/renego-and-resumption-NSS-with-OpenSSL/openssl-client.expect
+++ b/nss/Interoperability/renego-and-resumption-NSS-with-OpenSSL/openssl-client.expect
@@ -1,0 +1,13 @@
+#!/usr/bin/expect
+set timeout 10
+spawn /bin/sh -c "$argv"
+expect {
+    "Verify return code: 0 " {
+        send "GET / HTTP/1.0\r\r"
+        expect "Server: Generic Web Server" {
+            close
+            exit 0
+        }
+    }
+}
+exit 1

--- a/nss/Interoperability/renego-and-resumption-NSS-with-OpenSSL/runtest.sh
+++ b/nss/Interoperability/renego-and-resumption-NSS-with-OpenSSL/runtest.sh
@@ -343,6 +343,101 @@ rlJournalStart
             continue
         fi
 
+        rlPhaseStartTest "OpenSSL server NSS client ${C_NAME[$j]} cipher $prot protocol"
+            options=(openssl s_server -www -key ${C_KEY[$j]})
+            options+=(-cert ${C_CERT[$j]})
+            options+=(-CAfile '<(cat $(x509Cert ca) ${C_SUBCA[$j]})')
+            options+=(-cipher ${C_OPENSSL[$j]})
+            rlRun "${options[*]} >server.log 2>server.err &"
+            openssl_pid=$!
+            rlRun "rlWaitForSocket 4433 -p $openssl_pid"
+            options=(${CLIENT_UTIL})
+            options+=(-h localhost -p 4433)
+            options+=(-d sql:./ca-db/)
+            options+=(-c :${C_ID[$j]})
+            if [[ $prot == "tls1_2" ]]; then
+                options+=(-V tls1.0:)
+            else
+                options+=(-V tls1.0:tls1.1)
+            fi
+            rlRun -s "${options[*]} <<< 'GET /'"
+            rlAssertGrep "New, TLSv1/SSLv3," "$rlRun_LOG"
+            rlRun "kill $openssl_pid"
+            rlRun "rlWait -s SIGKILL $openssl_pid" 143
+            if ! rlGetPhaseState; then
+                rlRun "cat server.log" 0 "Server stdout"
+                rlRun "cat server.err" 0 "Server stderr"
+            fi
+        rlPhaseEnd
+
+        rlPhaseStartTest "OpenSSL server NSS client ${C_NAME[$j]} cipher $prot protocol client auth"
+            rlLogInfo "Preparing NSS database"
+            rlRun "mkdir nssdb/"
+            rlRun "certutil -N --empty-password -d sql:./nssdb/"
+            rlRun "certutil -A -d sql:./nssdb/ -n ca -t 'cC,,' -a -i $(x509Cert ca)"
+            rlRun "certutil -A -d sql:./nssdb/ -n subca -t ',,' -a -i ${C_SUBCA[$j]}"
+            clnt_nickname="${C_CLNT_KEY[$j]%%/*}"
+            rlRun "pk12util -i $(x509Key --pkcs12 --with-cert $clnt_nickname) -d sql:./nssdb -W ''"
+
+            rlLogInfo "Test proper"
+            options=(openssl s_server -www -key ${C_KEY[$j]})
+            options+=(-cert ${C_CERT[$j]})
+            options+=(-CAfile '<(cat $(x509Cert ca) ${C_SUBCA[$j]})')
+            options+=(-cipher ${C_OPENSSL[$j]})
+            options+=(-Verify 1 -verify_return_error)
+            rlRun "${options[*]} >server.log 2>server.err &"
+            openssl_pid=$!
+            rlRun "rlWaitForSocket 4433 -p $openssl_pid"
+            options=(${CLIENT_UTIL})
+            options+=(-h localhost -p 4433)
+            options+=(-d sql:./nssdb/)
+            options+=(-c :${C_ID[$j]})
+            if [[ $prot == "tls1_2" ]]; then
+                options+=(-V tls1.0:)
+            else
+                options+=(-V tls1.0:tls1.1)
+            fi
+            options+=(-n $clnt_nickname)
+            rlRun -s "${options[*]} <<< 'GET /'"
+            rlAssertGrep "New, TLSv1/SSLv3," "$rlRun_LOG"
+            rlRun "kill $openssl_pid"
+            rlRun "rlWait -s SIGKILL $openssl_pid" 143
+            if ! rlGetPhaseState; then
+                rlRun "cat server.log" 0 "Server stdout"
+                rlRun "cat server.err" 0 "Server stderr"
+            fi
+            rlRun "rm -rf nssdb/"
+        rlPhaseEnd
+
+
+        rlPhaseStartTest "OpenSSL server NSS client ${C_NAME[$j]} cipher $prot protocol renegotiation"
+            options=(openssl s_server -www -key ${C_KEY[$j]})
+            options+=(-cert ${C_CERT[$j]})
+            options+=(-CAfile '<(cat $(x509Cert ca) ${C_SUBCA[$j]})')
+            options+=(-cipher ${C_OPENSSL[$j]})
+            rlRun "${options[*]} >server.log 2>server.err &"
+            openssl_pid=$!
+            rlRun "rlWaitForSocket 4433 -p $openssl_pid"
+            options=(${CLIENT_UTIL})
+            options+=(-h localhost -p 4433)
+            options+=(-d sql:./ca-db/)
+            options+=(-c :${C_ID[$j]})
+            options+=(-r 1)
+            if [[ $prot == "tls1_2" ]]; then
+                options+=(-V tls1.0:)
+            else
+                options+=(-V tls1.0:tls1.1)
+            fi
+            rlRun -s "expect nss-client.expect ${options[*]}"
+            rlAssertGrep "New, TLSv1/SSLv3," "$rlRun_LOG"
+            rlRun "kill $openssl_pid"
+            rlRun "rlWait -s SIGKILL $openssl_pid" 143
+            if ! rlGetPhaseState; then
+                rlRun "cat server.log" 0 "Server stdout"
+                rlRun "cat server.err" 0 "Server stderr"
+            fi
+        rlPhaseEnd
+
         rlPhaseStartTest "OpenSSL server NSS client ${C_NAME[$j]} cipher $prot protocol client auth renegotiation"
             rlLogInfo "Preparing NSS database"
             rlRun "mkdir nssdb/"
@@ -381,34 +476,6 @@ rlJournalStart
                 rlRun "cat server.err" 0 "Server stderr"
             fi
             rlRun "rm -rf nssdb/"
-        rlPhaseEnd
-
-        rlPhaseStartTest "OpenSSL server NSS client ${C_NAME[$j]} cipher $prot protocol renegotiation"
-            options=(openssl s_server -www -key ${C_KEY[$j]})
-            options+=(-cert ${C_CERT[$j]})
-            options+=(-CAfile '<(cat $(x509Cert ca) ${C_SUBCA[$j]})')
-            options+=(-cipher ${C_OPENSSL[$j]})
-            rlRun "${options[*]} >server.log 2>server.err &"
-            openssl_pid=$!
-            rlRun "rlWaitForSocket 4433 -p $openssl_pid"
-            options=(${CLIENT_UTIL})
-            options+=(-h localhost -p 4433)
-            options+=(-d sql:./ca-db/)
-            options+=(-c :${C_ID[$j]})
-            options+=(-r 1)
-            if [[ $prot == "tls1_2" ]]; then
-                options+=(-V tls1.0:)
-            else
-                options+=(-V tls1.0:tls1.1)
-            fi
-            rlRun -s "expect nss-client.expect ${options[*]}"
-            rlAssertGrep "New, TLSv1/SSLv3," "$rlRun_LOG"
-            rlRun "kill $openssl_pid"
-            rlRun "rlWait -s SIGKILL $openssl_pid" 143
-            if ! rlGetPhaseState; then
-                rlRun "cat server.log" 0 "Server stdout"
-                rlRun "cat server.err" 0 "Server stderr"
-            fi
         rlPhaseEnd
 
       for sess in sessionID ticket; do
@@ -534,10 +601,10 @@ rlJournalStart
                 options+=(-tls1_1)
             fi
             rlRun -s "expect openssl-client.expect ${options[*]}"
-            rlRun "kill $nss_pid"
-            rlRun "rlWait -s SIGKILL $nss_pid" 143
             rlAssertGrep "GET / HTTP/1.0" "$rlRun_LOG"
             rlAssertGrep "Server: Generic Web Server" "$rlRun_LOG"
+            rlRun "kill $nss_pid"
+            rlRun "rlWait -s SIGKILL $nss_pid" 143
             if ! rlGetPhaseState; then
                 rlRun "cat server.log" 0 "Server stdout"
                 rlRun "cat server.err" 0 "Server stderr"

--- a/nss/Interoperability/renego-and-resumption-NSS-with-OpenSSL/runtest.sh
+++ b/nss/Interoperability/renego-and-resumption-NSS-with-OpenSSL/runtest.sh
@@ -360,7 +360,7 @@ rlJournalStart
             else
                 options+=(-V tls1.0:tls1.1)
             fi
-            rlRun -s "${options[*]} <<< 'GET /'"
+            rlRun -s "${options[*]} <<< 'GET / HTTP/1.0\n\n'"
             rlAssertGrep "New, TLSv1/SSLv3," "$rlRun_LOG"
             rlRun "kill $openssl_pid"
             rlRun "rlWait -s SIGKILL $openssl_pid" 143
@@ -398,7 +398,7 @@ rlJournalStart
                 options+=(-V tls1.0:tls1.1)
             fi
             options+=(-n $clnt_nickname)
-            rlRun -s "${options[*]} <<< 'GET /'"
+            rlRun -s "${options[*]} <<< 'GET / HTTP/1.0\n\n'"
             rlAssertGrep "New, TLSv1/SSLv3," "$rlRun_LOG"
             rlRun "kill $openssl_pid"
             rlRun "rlWait -s SIGKILL $openssl_pid" 143

--- a/nss/Interoperability/renego-and-resumption-NSS-with-OpenSSL/runtest.sh
+++ b/nss/Interoperability/renego-and-resumption-NSS-with-OpenSSL/runtest.sh
@@ -45,7 +45,7 @@ rlJournalStart
         rlAssertRpm --all
         rlRun "rlImport openssl/certgen"
         rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
-        rlRun "cp nss-client.expect $TmpDir"
+        rlRun "cp nss-{client,server}.expect openssl-client.expect $TmpDir"
         rlRun "pushd $TmpDir"
         rlRun "x509KeyGen ca"
         rlRun "x509KeyGen rsa-ca"
@@ -410,7 +410,6 @@ rlJournalStart
         rlPhaseEnd
       done
 
-    if false; then
         rlPhaseStartTest "NSS server OpenSSL client ${C_NAME[$j]} cipher $prot protocol"
             rlLogInfo "Preparing NSS database"
             rlRun "mkdir nssdb/"
@@ -451,7 +450,6 @@ rlJournalStart
             fi
             rlRun "rm -rf nssdb/" 0 "Clean up NSS database"
         rlPhaseEnd
-    fi
 
         rlPhaseStartTest "OpenSSL server NSS client ${C_NAME[$j]} cipher $prot protocol client auth renegotiation"
             rlLogInfo "Preparing NSS database"
@@ -496,7 +494,7 @@ rlJournalStart
     # looks like strsclnt can't handle client certificates with OpenSSL
     if false; then
       for sess in sessionID ticket; do
-        rlPhaseStartTest "OpenSSL server NSS client ${C_NAME[$j]} cipher $prot protocol client authentication $sess resumption"
+        rlPhaseStartTest "OpenSSL server NSS client ${C_NAME[$j]} cipher $prot protocol client auth $sess resumption"
             rlLogInfo "Preparing NSS database"
             rlRun "mkdir nssdb/"
             rlRun "certutil -N --empty-password -d sql:./nssdb/"
@@ -547,7 +545,192 @@ rlJournalStart
       done
     fi
 
-    if false; then
+        rlPhaseStartTest "NSS server OpenSSL client ${C_NAME[$j]} cipher $prot protocol renegotiation"
+            rlLogInfo "Preparing NSS database"
+            rlRun "mkdir nssdb/"
+            rlRun "certutil -N --empty-password -d sql:./nssdb/"
+            rlRun "certutil -A -d sql:./nssdb/ -n ca -t 'cC,,' -a -i $(x509Cert ca)"
+            rlRun "certutil -A -d sql:./nssdb/ -n subca -t ',,' -a -i ${C_SUBCA[$j]}"
+            rlRun "pk12util -i $(x509Key --pkcs12 --with-cert ${C_KEY[$j]%%/*}) -d sql:./nssdb -W ''"
+
+            rlLogInfo "Test proper"
+            declare -a options=()
+            options+=(${SERVER_UTIL} -d sql:./nssdb/ -p 4433 -V tls1.0:
+                      -c :${C_ID[$j]} -H 1)
+            if [[ ${C_KEY[$j]} =~ 'ecdsa' ]]; then
+                options+=(-e ${C_KEY[$j]%%/*})
+            elif [[ ${C_KEY[$j]} =~ 'dsa' ]]; then
+                options+=(-S ${C_KEY[$j]%%/*})
+            else
+                options+=(-n ${C_KEY[$j]%%/*})
+            fi
+            rlRun "expect nss-server.expect ${options[*]} >server.log 2>server.err &"
+            nss_pid=$!
+            rlRun "rlWaitForSocket 4433 -p $nss_pid"
+            options=(openssl s_client)
+            options+=(-CAfile $(x509Cert ca))
+            options+=(-cipher ${C_OPENSSL[$j]})
+            options+=(-connect localhost:4433)
+            if [[ $prot == "tls1_1" ]]; then
+                options+=(-tls1_1)
+            fi
+            rlRun -s "(sleep 0.5; echo R; sleep 0.5; echo Q) | ${options[*]}"
+            rlRun "kill $nss_pid"
+            rlRun "rlWait -s SIGKILL $nss_pid" 143
+            rlAssertGrep "RENEGOTIATING" "$rlRun_LOG"
+            rlRun "grep -A 10 RENEGOTIATING $rlRun_LOG | grep 'verify return:1'"
+            if ! rlGetPhaseState; then
+                rlRun "cat server.log" 0 "Server stdout"
+                rlRun "cat server.err" 0 "Server stderr"
+            fi
+            rlRun "rm -rf nssdb/" 0 "Clean up NSS database"
+        rlPhaseEnd
+
+        rlPhaseStartTest "NSS server OpenSSL client ${C_NAME[$j]} cipher $prot protocol client auth renegotiation"
+            rlLogInfo "Preparing NSS database"
+            rlRun "mkdir nssdb/"
+            rlRun "certutil -N --empty-password -d sql:./nssdb/"
+            rlRun "certutil -A -d sql:./nssdb/ -n ca -t 'cCT,,' -a -i $(x509Cert ca)"
+            rlRun "certutil -A -d sql:./nssdb/ -n subca -t ',,' -a -i ${C_SUBCA[$j]}"
+            rlRun "pk12util -i $(x509Key --pkcs12 --with-cert ${C_KEY[$j]%%/*}) -d sql:./nssdb -W ''"
+
+            rlLogInfo "Test proper"
+            declare -a options=()
+            options+=(${SERVER_UTIL} -d sql:./nssdb/ -p 4433 -V tls1.0: -rr
+                      -c :${C_ID[$j]} -H 1)
+            if [[ ${C_KEY[$j]} =~ 'ecdsa' ]]; then
+                options+=(-e ${C_KEY[$j]%%/*})
+            elif [[ ${C_KEY[$j]} =~ 'dsa' ]]; then
+                options+=(-S ${C_KEY[$j]%%/*})
+            else
+                options+=(-n ${C_KEY[$j]%%/*})
+            fi
+            rlRun "expect nss-server.expect ${options[*]} >server.log 2>server.err &"
+            nss_pid=$!
+            rlRun "rlWaitForSocket 4433 -p $nss_pid"
+            options=(openssl s_client)
+            options+=(-CAfile $(x509Cert ca))
+            options+=(-cipher ${C_OPENSSL[$j]})
+            options+=(-connect localhost:4433)
+            options+=(-cert ${C_CLNT_CERT[$j]} -key ${C_CLNT_KEY[$j]})
+            if [[ $prot == "tls1_1" ]]; then
+                options+=(-tls1_1)
+            fi
+            rlRun -s "(sleep 0.5; echo R; sleep 0.5; echo Q) | ${options[*]}"
+            rlRun "kill $nss_pid"
+            rlRun "rlWait -s SIGKILL $nss_pid" 143
+            rlAssertGrep "RENEGOTIATING" "$rlRun_LOG"
+            rlRun "grep -A 10 RENEGOTIATING $rlRun_LOG | grep 'verify return:1'"
+            if ! rlGetPhaseState; then
+                rlRun "cat server.log" 0 "Server stdout"
+                rlRun "cat server.err" 0 "Server stderr"
+            fi
+            rlRun "rm -rf nssdb/" 0 "Clean up NSS database"
+        rlPhaseEnd
+
+    for sess in sessionID ticket; do
+        rlPhaseStartTest "NSS server OpenSSL client ${C_NAME[$j]} cipher $prot protocol $sess resumption"
+            rlLogInfo "Preparing NSS database"
+            rlRun "mkdir nssdb/"
+            rlRun "certutil -N --empty-password -d sql:./nssdb/"
+            rlRun "certutil -A -d sql:./nssdb/ -n ca -t 'cC,,' -a -i $(x509Cert ca)"
+            rlRun "certutil -A -d sql:./nssdb/ -n subca -t ',,' -a -i ${C_SUBCA[$j]}"
+            rlRun "pk12util -i $(x509Key --pkcs12 --with-cert ${C_KEY[$j]%%/*}) -d sql:./nssdb -W ''"
+
+            rlLogInfo "Test proper"
+            declare -a options=()
+            options+=(${SERVER_UTIL} -d sql:./nssdb/ -p 4433 -V tls1.0:
+                      -c :${C_ID[$j]} -H 1)
+            if [[ ${C_KEY[$j]} =~ 'ecdsa' ]]; then
+                options+=(-e ${C_KEY[$j]%%/*})
+            elif [[ ${C_KEY[$j]} =~ 'dsa' ]]; then
+                options+=(-S ${C_KEY[$j]%%/*})
+            else
+                options+=(-n ${C_KEY[$j]%%/*})
+            fi
+            rlRun "expect nss-server.expect ${options[*]} >server.log 2>server.err &"
+            nss_pid=$!
+            rlRun "rlWaitForSocket 4433 -p $nss_pid"
+            options=(openssl s_client)
+            options+=(-CAfile $(x509Cert ca))
+            options+=(-cipher ${C_OPENSSL[$j]})
+            options+=(-connect localhost:4433)
+            if [[ $sess == "sessionID" ]]; then
+                options+=(-no_ticket)
+            fi
+            if [[ $prot == "tls1_1" ]]; then
+                options+=(-tls1_1)
+            fi
+            rlRun -s "${options[*]} -sess_out sess.pem </dev/null"
+            rlAssertGrep "New, TLSv1/SSLv3" $rlRun_LOG
+            rlAssertNotGrep "Reused, TLSv1/SSLv3" $rlRun_LOG
+            rlAssertGrep "Verify return code: 0 (ok)" $rlRun_LOG
+            rlRun -s "${options[*]} -sess_in sess.pem </dev/null"
+            rlAssertGrep "Reused, TLSv1/SSLv3" $rlRun_LOG
+            rlAssertNotGrep "New, TLSv1/SSLv3" $rlRun_LOG
+            rlAssertGrep "Verify return code: 0 (ok)" $rlRun_LOG
+            rlRun "kill $nss_pid"
+            rlRun "rlWait -s SIGKILL $nss_pid" 143
+            if ! rlGetPhaseState; then
+                rlRun "cat server.log" 0 "Server stdout"
+                rlRun "cat server.err" 0 "Server stderr"
+            fi
+            rlRun "rm -rf nssdb/" 0 "Clean up NSS database"
+        rlPhaseEnd
+    done
+
+    for sess in sessionID ticket; do
+        rlPhaseStartTest "NSS server OpenSSL client ${C_NAME[$j]} cipher $prot protocol client auth $sess resumption"
+            rlLogInfo "Preparing NSS database"
+            rlRun "mkdir nssdb/"
+            rlRun "certutil -N --empty-password -d sql:./nssdb/"
+            rlRun "certutil -A -d sql:./nssdb/ -n ca -t 'cCT,,' -a -i $(x509Cert ca)"
+            rlRun "certutil -A -d sql:./nssdb/ -n subca -t ',,' -a -i ${C_SUBCA[$j]}"
+            rlRun "pk12util -i $(x509Key --pkcs12 --with-cert ${C_KEY[$j]%%/*}) -d sql:./nssdb -W ''"
+
+            rlLogInfo "Test proper"
+            declare -a options=()
+            options+=(${SERVER_UTIL} -d sql:./nssdb/ -p 4433 -V tls1.0: -rr
+                      -c :${C_ID[$j]} -H 1)
+            if [[ ${C_KEY[$j]} =~ 'ecdsa' ]]; then
+                options+=(-e ${C_KEY[$j]%%/*})
+            elif [[ ${C_KEY[$j]} =~ 'dsa' ]]; then
+                options+=(-S ${C_KEY[$j]%%/*})
+            else
+                options+=(-n ${C_KEY[$j]%%/*})
+            fi
+            rlRun "expect nss-server.expect ${options[*]} >server.log 2>server.err &"
+            nss_pid=$!
+            rlRun "rlWaitForSocket 4433 -p $nss_pid"
+            options=(openssl s_client)
+            options+=(-CAfile $(x509Cert ca))
+            options+=(-cipher ${C_OPENSSL[$j]})
+            options+=(-connect localhost:4433)
+            options+=(-cert ${C_CLNT_CERT[$j]} -key ${C_CLNT_KEY[$j]})
+            if [[ $sess == "sessionID" ]]; then
+                options+=(-no_ticket)
+            fi
+            if [[ $prot == "tls1_1" ]]; then
+                options+=(-tls1_1)
+            fi
+            rlRun -s "${options[*]} -sess_out sess.pem </dev/null"
+            rlAssertGrep "New, TLSv1/SSLv3" $rlRun_LOG
+            rlAssertNotGrep "Reused, TLSv1/SSLv3" $rlRun_LOG
+            rlAssertGrep "Verify return code: 0 (ok)" $rlRun_LOG
+            rlRun -s "${options[*]} -sess_in sess.pem </dev/null"
+            rlAssertGrep "Reused, TLSv1/SSLv3" $rlRun_LOG
+            rlAssertNotGrep "New, TLSv1/SSLv3" $rlRun_LOG
+            rlAssertGrep "Verify return code: 0 (ok)" $rlRun_LOG
+            rlRun "kill $nss_pid"
+            rlRun "rlWait -s SIGKILL $nss_pid" 143
+            if ! rlGetPhaseState; then
+                rlRun "cat server.log" 0 "Server stdout"
+                rlRun "cat server.err" 0 "Server stderr"
+            fi
+            rlRun "rm -rf nssdb/" 0 "Clean up NSS database"
+        rlPhaseEnd
+    done
+
         rlPhaseStartTest "NSS server OpenSSL client ${C_NAME[$j]} cipher $prot protocol client auth"
             rlLogInfo "Preparing NSS database"
             rlRun "mkdir nssdb/"
@@ -589,7 +772,6 @@ rlJournalStart
             fi
             rlRun "rm -rf nssdb/" 0 "Clean up NSS database"
         rlPhaseEnd
-    fi
       done
     done
 

--- a/nss/Interoperability/renego-and-resumption-NSS-with-OpenSSL/runtest.sh
+++ b/nss/Interoperability/renego-and-resumption-NSS-with-OpenSSL/runtest.sh
@@ -749,7 +749,10 @@ rlJournalStart
             rlLogInfo "Test proper"
             declare -a options=()
             options+=(${SERVER_UTIL} -d sql:./nssdb/ -p 4433 -V tls1.0:
-                      -c :${C_ID[$j]} -u -H 1)
+                      -c :${C_ID[$j]} -H 1)
+            if [[ $sess == "ticket" ]]; then
+                options+=(-u)
+            fi
             if [[ ${C_KEY[$j]} =~ 'ecdsa' ]]; then
                 options+=(-e ${C_KEY[$j]%%/*})
             elif [[ ${C_KEY[$j]} =~ 'dsa' ]]; then
@@ -801,6 +804,9 @@ rlJournalStart
             declare -a options=()
             options+=(${SERVER_UTIL} -d sql:./nssdb/ -p 4433 -V tls1.0: -rr
                       -c :${C_ID[$j]} -H 1)
+            if [[ $sess == "ticket" ]]; then
+                options+=(-u)
+            fi
             if [[ ${C_KEY[$j]} =~ 'ecdsa' ]]; then
                 options+=(-e ${C_KEY[$j]%%/*})
             elif [[ ${C_KEY[$j]} =~ 'dsa' ]]; then

--- a/nss/Interoperability/renego-and-resumption-NSS-with-OpenSSL/runtest.sh
+++ b/nss/Interoperability/renego-and-resumption-NSS-with-OpenSSL/runtest.sh
@@ -640,7 +640,7 @@ rlJournalStart
             rlLogInfo "Test proper"
             declare -a options=()
             options+=(${SERVER_UTIL} -d sql:./nssdb/ -p 4433 -V tls1.0:
-                      -c :${C_ID[$j]} -H 1)
+                      -c :${C_ID[$j]} -u -H 1)
             if [[ ${C_KEY[$j]} =~ 'ecdsa' ]]; then
                 options+=(-e ${C_KEY[$j]%%/*})
             elif [[ ${C_KEY[$j]} =~ 'dsa' ]]; then


### PR DESCRIPTION
This PR extends the nss/renego-and-resumption-NSS-with-OpenSSL test to cover all combinations of settings for renegotiation and resumption protocols.

What's being tested (server-client):
- OpenSSL-NSS - simple communication (**NEW**)
- OpenSSL-NSS - simple communication with client authentication (**NEW**)
- OpenSSL-NSS - renegotiation
- OpenSSL-NSS - renegotiation with client authentication
- OpenSSL-NSS - resumption (sessionID, SessionTicket)
- OpenSSL-NSS - resumption (sessionID, SessionTicket) with client authentication (**BUG**)
- NSS-OpenSSL - simple communication (**FIXED**)
- NSS-OpenSSL - simple communication with client authentication (**FIXED**)
- NSS-OpenSSL - renegotiation (**NEW**)
- NSS-OpenSSL - renegotiation with client authentication (**NEW**)
- NSS-OpenSSL - resumption (sessionID, SessionTicket) (**NEW**, **BUG**)
- NSS-OpenSSL - resumption (sessionID, SessionTicket) with client authentication (**NEW**, **BUG**)

This PR **must not** be merged until following issues are resolved:
- Beakerlib does not support CentOS in `rlIsRHEL` function
  - Discussed with devels, a new function `rlIsCentos` should be implemented soon
- Segfault/server breakdown in NSS when using ECDHE-ECDSA ciphersuites
  - RHEL 6 - [BZ#1397482](https://bugzilla.redhat.com/show_bug.cgi?id=1397482)
  - RHEL 7 - [BZ#1397410](https://bugzilla.redhat.com/show_bug.cgi?id=1397410)
  - Upstream - [MBZ#1320695](https://bugzilla.mozilla.org/show_bug.cgi?id=1320695)
- strsclnt cannot handle client certificates during session resumption
  - RHEL 6 - [BZ#1397486](https://bugzilla.redhat.com/show_bug.cgi?id=1397486)
  - RHEL 7 - [BZ#1397472](https://bugzilla.redhat.com/show_bug.cgi?id=1397472)
  - Upstream - [MBZ#1320708](https://bugzilla.mozilla.org/show_bug.cgi?id=1320708)
- session resumption does not work for DHE-DSS ciphersuites
  - RHEL 6 - [BZ#1397478](https://bugzilla.redhat.com/show_bug.cgi?id=1397478)
  - RHEL 7 - [BZ#1397365](https://bugzilla.redhat.com/show_bug.cgi?id=1397365)
  - Upstream - [MBZ#1174677](https://bugzilla.mozilla.org/show_bug.cgi?id=1174677)
  - This one will most likely not get fixed
