### PR TITLE
gnutls/resumption-with-NSS: Test extension

### DIFF
--- a/gnutls/Interoperability/resumption-with-NSS/runtest.sh
+++ b/gnutls/Interoperability/resumption-with-NSS/runtest.sh
@@ -43,47 +43,481 @@ rlJournalStart
         rlRun "rlImport openssl/certgen"
         rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
         rlRun "pushd $TmpDir"
+        rlRun "x509KeyGen ca"
         rlRun "x509KeyGen rsa-ca"
+        rlRun "x509KeyGen -t dsa dsa-ca"
+        rlRun "x509KeyGen -t ecdsa ecdsa-ca"
         rlRun "x509KeyGen rsa-server"
-        rlRun "x509SelfSign rsa-ca"
-        rlRun "x509CertSign --CA rsa-ca --DN CN=localhost4 rsa-server"
-        rlRun "mkdir ca-db" 0 "Directory with just CA certificate"
-        rlRun "certutil -N --empty-password -d sql:./ca-db" 0 "Create database for CA cert"
-        rlRun "certutil -A -d sql:./ca-db -n ca -t 'cC,,' -a -i $(x509Cert rsa-ca)"\
-            0 "Import CA certificate"
+        rlRun "x509KeyGen -t dsa dsa-server"
+        rlRun "x509KeyGen -t ecdsa ecdsa-server"
+        rlRun "x509KeyGen rsa-client"
+        rlRun "x509KeyGen -t dsa dsa-client"
+        rlRun "x509KeyGen -t ecdsa ecdsa-client"
+        rlRun "x509SelfSign ca"
+        rlRun "x509CertSign --CA ca -t ca --DN 'CN=RSA CA' rsa-ca"
+        rlRun "x509CertSign --CA ca -t ca --DN 'CN=DSA CA' dsa-ca"
+        rlRun "x509CertSign --CA ca -t ca --DN 'CN=ECDSA CA' ecdsa-ca"
+        rlRun "x509CertSign --CA rsa-ca rsa-server"
+        rlRun "x509CertSign --CA dsa-ca dsa-server"
+        rlRun "x509CertSign --CA ecdsa-ca ecdsa-server"
+        rlRun "x509CertSign --CA rsa-ca -t webclient rsa-client"
+        rlRun "x509CertSign --CA dsa-ca -t webclient dsa-client"
+        rlRun "x509CertSign --CA ecdsa-ca -t webclient ecdsa-client"
+        rlRun "x509DumpCert ca" 0 "Root CA"
+        rlRun "x509DumpCert rsa-ca" 0 "Intermediate RSA CA"
+        rlRun "x509DumpCert dsa-ca" 0 "Intermediate DSA CA"
+        rlRun "x509DumpCert ecdsa-ca" 0 "Intermediate ECDSA CA"
+        rlRun "x509DumpCert rsa-server" 0 "Server RSA certificate"
+        rlRun "x509DumpCert dsa-server" 0 "Server DSA certificate"
+        rlRun "x509DumpCert ecdsa-server" 0 "Server ECDSA certificate"
+        rlRun "x509DumpCert rsa-client" 0 "Client RSA certificate"
+        rlRun "x509DumpCert dsa-client" 0 "Client DSA certificate"
+        rlRun "x509DumpCert ecdsa-client" 0 "Client ECDSA certificate"
+
+        # Tested combinations
+
+        # Structure definiton:
+        # C_NAME          IETF name of a ciphersuite
+        # C_NSS           NSS ciphersuite ID
+        # C_GNUTLS        GNUTLS ciphersuite ID (unused for now)
+        # C_TLS1_2_ONLY   new ciphersuite in TLS1.2
+        # C_SUBCA         intermediate CA
+        # C_CERT          EE (end-entity) certificate
+        # C_KEY           EE key
+        # C_CLNT_CERT     client certificate
+        # C_CLNT_KEY      client key
+        i=0
+
+        C_NAME[$i]="TLS_RSA_WITH_AES_128_CBC_SHA"
+        C_NSS[$i]="002F"
+        C_GNUTLS[$i]="TLS_RSA_AES_128_CBC_SHA1"
+        C_TLS1_2_ONLY[$i]="False"
+        C_SUBCA[$i]="$(x509Cert rsa-ca)"
+        C_CERT[$i]="$(x509Cert rsa-server)"
+        C_KEY[$i]="$(x509Key rsa-server)"
+        C_CLNT_CERT[$i]="$(x509Cert rsa-client)"
+        C_CLNT_KEY[$i]="$(x509Key rsa-client)"
+        i=$(($i+1))
+
+        C_NAME[$i]="TLS_RSA_WITH_AES_256_CBC_SHA256"
+        C_NSS[$i]="003D"
+        C_GNUTLS[$i]="TLS_RSA_AES_256_CBC_SHA256"
+        C_TLS1_2_ONLY[$i]="True"
+        C_SUBCA[$i]="$(x509Cert rsa-ca)"
+        C_CERT[$i]="$(x509Cert rsa-server)"
+        C_KEY[$i]="$(x509Key rsa-server)"
+        C_CLNT_CERT[$i]="$(x509Cert rsa-client)"
+        C_CLNT_KEY[$i]="$(x509Key rsa-client)"
+        i=$(($i+1))
+
+        C_NAME[$i]="TLS_RSA_WITH_AES_128_GCM_SHA256"
+        C_NSS[$i]="009C"
+        C_GNUTLS[$i]="TLS_RSA_AES_128_GCM_SHA256"
+        C_TLS1_2_ONLY[$i]="True"
+        C_SUBCA[$i]="$(x509Cert rsa-ca)"
+        C_CERT[$i]="$(x509Cert rsa-server)"
+        C_KEY[$i]="$(x509Key rsa-server)"
+        C_CLNT_CERT[$i]="$(x509Cert rsa-client)"
+        C_CLNT_KEY[$i]="$(x509Key rsa-client)"
+        i=$(($i+1))
+
+        # NSS on RHEL-6 does not support SHA-384 PRF
+        if ! rlIsRHEL 6; then
+            C_NAME[$i]="TLS_RSA_WITH_AES_256_GCM_SHA384"
+            C_NSS[$i]="009D"
+            C_GNUTLS[$i]="TLS_RSA_AES_256_GCM_SHA384"
+            C_TLS1_2_ONLY[$i]="True"
+            C_SUBCA[$i]="$(x509Cert rsa-ca)"
+            C_CERT[$i]="$(x509Cert rsa-server)"
+            C_KEY[$i]="$(x509Key rsa-server)"
+            C_CLNT_CERT[$i]="$(x509Cert rsa-client)"
+            C_CLNT_KEY[$i]="$(x509Key rsa-client)"
+            i=$(($i+1))
+        fi
+
+        C_NAME[$i]="TLS_DHE_RSA_WITH_AES_128_CBC_SHA"
+        C_NSS[$i]="0033"
+        C_GNUTLS[$i]="TLS_DHE_RSA_AES_128_CBC_SHA1"
+        C_TLS1_2_ONLY[$i]="False"
+        C_SUBCA[$i]="$(x509Cert rsa-ca)"
+        C_CERT[$i]="$(x509Cert rsa-server)"
+        C_KEY[$i]="$(x509Key rsa-server)"
+        C_CLNT_CERT[$i]="$(x509Cert rsa-client)"
+        C_CLNT_KEY[$i]="$(x509Key rsa-client)"
+        i=$(($i+1))
+
+        C_NAME[$i]="TLS_DHE_RSA_WITH_AES_256_CBC_SHA256"
+        C_NSS[$i]="006B"
+        C_GNUTLS[$i]="TLS_DHE_RSA_AES_256_CBC_SHA256"
+        C_TLS1_2_ONLY[$i]="True"
+        C_SUBCA[$i]="$(x509Cert rsa-ca)"
+        C_CERT[$i]="$(x509Cert rsa-server)"
+        C_KEY[$i]="$(x509Key rsa-server)"
+        C_CLNT_CERT[$i]="$(x509Cert rsa-client)"
+        C_CLNT_KEY[$i]="$(x509Key rsa-client)"
+        i=$(($i+1))
+
+        C_NAME[$i]="TLS_DHE_RSA_WITH_AES_128_GCM_SHA256"
+        C_NSS[$i]="009E"
+        C_GNUTLS[$i]="TLS_DHE_RSA_AES_128_GCM_SHA256"
+        C_TLS1_2_ONLY[$i]="True"
+        C_SUBCA[$i]="$(x509Cert rsa-ca)"
+        C_CERT[$i]="$(x509Cert rsa-server)"
+        C_KEY[$i]="$(x509Key rsa-server)"
+        C_CLNT_CERT[$i]="$(x509Cert rsa-client)"
+        C_CLNT_KEY[$i]="$(x509Key rsa-client)"
+        i=$(($i+1))
+
+        if ! rlIsRHEL 6; then
+            C_NAME[$i]="TLS_DHE_RSA_WITH_AES_256_GCM_SHA384"
+            C_NSS[$i]="009F"
+            C_GNUTLS[$i]="TLS_DHE_RSA_AES_256_GCM_SHA384"
+            C_TLS1_2_ONLY[$i]="True"
+            C_SUBCA[$i]="$(x509Cert rsa-ca)"
+            C_CERT[$i]="$(x509Cert rsa-server)"
+            C_KEY[$i]="$(x509Key rsa-server)"
+            C_CLNT_CERT[$i]="$(x509Cert rsa-client)"
+            C_CLNT_KEY[$i]="$(x509Key rsa-client)"
+            i=$(($i+1))
+        fi
+
+        C_NAME[$i]="TLS_DHE_DSS_WITH_AES_128_CBC_SHA"
+        C_NSS[$i]="0032"
+        C_GNUTLS[$i]="TLS_DHE_DSS_AES_128_CBC_SHA1"
+        C_TLS1_2_ONLY[$i]="False"
+        C_SUBCA[$i]="$(x509Cert dsa-ca)"
+        C_CERT[$i]="$(x509Cert dsa-server)"
+        C_KEY[$i]="$(x509Key dsa-server)"
+        C_CLNT_CERT[$i]="$(x509Cert dsa-client)"
+        C_CLNT_KEY[$i]="$(x509Key dsa-client)"
+        i=$(($i+1))
+
+        C_NAME[$i]="TLS_DHE_DSS_WITH_AES_256_CBC_SHA256"
+        C_NSS[$i]="006A"
+        C_GNUTLS[$i]="TLS_DHE_DSS_AES_256_CBC_SHA256"
+        C_TLS1_2_ONLY[$i]="True"
+        C_SUBCA[$i]="$(x509Cert dsa-ca)"
+        C_CERT[$i]="$(x509Cert dsa-server)"
+        C_KEY[$i]="$(x509Key dsa-server)"
+        C_CLNT_CERT[$i]="$(x509Cert dsa-client)"
+        C_CLNT_KEY[$i]="$(x509Key dsa-client)"
+        i=$(($i+1))
+
+        C_NAME[$i]="TLS_DHE_DSS_WITH_AES_128_GCM_SHA256"
+        C_NSS[$i]="00A2"
+        C_GNUTLS[$i]="TLS_DHE_DSS_AES_128_GCM_SHA256"
+        C_TLS1_2_ONLY[$i]="True"
+        C_SUBCA[$i]="$(x509Cert dsa-ca)"
+        C_CERT[$i]="$(x509Cert dsa-server)"
+        C_KEY[$i]="$(x509Key dsa-server)"
+        C_CLNT_CERT[$i]="$(x509Cert dsa-client)"
+        C_CLNT_KEY[$i]="$(x509Key dsa-client)"
+        i=$(($i+1))
+
+        if ! rlIsRHEL 6; then
+            C_NAME[$i]="TLS_DHE_DSS_WITH_AES_256_GCM_SHA384"
+            C_NSS[$i]="00A3"
+            C_GNUTLS[$i]="TLS_DHE_DSS_AES_256_GCM_SHA384"
+            C_TLS1_2_ONLY[$i]="True"
+            C_SUBCA[$i]="$(x509Cert dsa-ca)"
+            C_CERT[$i]="$(x509Cert dsa-server)"
+            C_KEY[$i]="$(x509Key dsa-server)"
+            C_CLNT_CERT[$i]="$(x509Cert dsa-client)"
+            C_CLNT_KEY[$i]="$(x509Key dsa-client)"
+            i=$(($i+1))
+        fi
+
+        C_NAME[$i]="TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA"
+        C_NSS[$i]="C012"
+        C_GNUTLS[$i]="TLS_ECDHE_RSA_3DES_EDE_CBC_SHA1"
+        C_TLS1_2_ONLY[$i]="False"
+        C_SUBCA[$i]="$(x509Cert rsa-ca)"
+        C_CERT[$i]="$(x509Cert rsa-server)"
+        C_KEY[$i]="$(x509Key rsa-server)"
+        C_CLNT_CERT[$i]="$(x509Cert rsa-client)"
+        C_CLNT_KEY[$i]="$(x509Key rsa-client)"
+        i=$(($i+1))
+
+        if ! rlIsRHEL 6; then
+            C_NAME[$i]="TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384"
+            C_NSS[$i]="C028"
+            C_GNUTLS[$i]="TLS_ECDHE_RSA_AES_256_CBC_SHA384"
+            C_TLS1_2_ONLY[$i]="True"
+            C_SUBCA[$i]="$(x509Cert rsa-ca)"
+            C_CERT[$i]="$(x509Cert rsa-server)"
+            C_KEY[$i]="$(x509Key rsa-server)"
+            C_CLNT_CERT[$i]="$(x509Cert rsa-client)"
+            C_CLNT_KEY[$i]="$(x509Key rsa-client)"
+            i=$(($i+1))
+        fi
+
+        C_NAME[$i]="TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+        C_NSS[$i]="C02F"
+        C_GNUTLS[$i]="TLS_ECDHE_RSA_AES_128_GCM_SHA256"
+        C_TLS1_2_ONLY[$i]="True"
+        C_SUBCA[$i]="$(x509Cert rsa-ca)"
+        C_CERT[$i]="$(x509Cert rsa-server)"
+        C_KEY[$i]="$(x509Key rsa-server)"
+        C_CLNT_CERT[$i]="$(x509Cert rsa-client)"
+        C_CLNT_KEY[$i]="$(x509Key rsa-client)"
+        i=$(($i+1))
+
+        if ! rlIsRHEL 6; then
+            C_NAME[$i]="TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+            C_NSS[$i]="C030"
+            C_GNUTLS[$i]="TLS_ECDHE_RSA_AES_256_GCM_SHA384"
+            C_TLS1_2_ONLY[$i]="True"
+            C_SUBCA[$i]="$(x509Cert rsa-ca)"
+            C_CERT[$i]="$(x509Cert rsa-server)"
+            C_KEY[$i]="$(x509Key rsa-server)"
+            C_CLNT_CERT[$i]="$(x509Cert rsa-client)"
+            C_CLNT_KEY[$i]="$(x509Key rsa-client)"
+            i=$(($i+1))
+        fi
+
+        C_NAME[$i]="TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA"
+        C_NSS[$i]="C00A"
+        C_GNUTLS[$i]="TLS_ECDHE_ECDSA_AES_256_CBC_SHA1"
+        C_TLS1_2_ONLY[$i]="False"
+        C_SUBCA[$i]="$(x509Cert ecdsa-ca)"
+        C_CERT[$i]="$(x509Cert ecdsa-server)"
+        C_KEY[$i]="$(x509Key ecdsa-server)"
+        C_CLNT_CERT[$i]="$(x509Cert ecdsa-client)"
+        C_CLNT_KEY[$i]="$(x509Key ecdsa-client)"
+        i=$(($i+1))
+
+        C_NAME[$i]="TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256"
+        C_NSS[$i]="C023"
+        C_GNUTLS[$i]="TLS_ECDHE_ECDSA_AES_128_CBC_SHA256"
+        C_TLS1_2_ONLY[$i]="True"
+        C_SUBCA[$i]="$(x509Cert ecdsa-ca)"
+        C_CERT[$i]="$(x509Cert ecdsa-server)"
+        C_KEY[$i]="$(x509Key ecdsa-server)"
+        C_CLNT_CERT[$i]="$(x509Cert ecdsa-client)"
+        C_CLNT_KEY[$i]="$(x509Key ecdsa-client)"
+        i=$(($i+1))
+
+        C_NAME[$i]="TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+        C_NSS[$i]="C02B"
+        C_GNUTLS[$i]="TLS_ECDHE_ECDSA_AES_128_GCM_SHA256"
+        C_TLS1_2_ONLY[$i]="True"
+        C_SUBCA[$i]="$(x509Cert ecdsa-ca)"
+        C_CERT[$i]="$(x509Cert ecdsa-server)"
+        C_KEY[$i]="$(x509Key ecdsa-server)"
+        C_CLNT_CERT[$i]="$(x509Cert ecdsa-client)"
+        C_CLNT_KEY[$i]="$(x509Key ecdsa-client)"
+        i=$(($i+1))
+
+        if ! rlIsRHEL 6; then
+            C_NAME[$i]="TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
+            C_NSS[$i]="C02C"
+            C_GNUTLS[$i]="TLS_ECDHE_ECDSA_AES_256_GCM_SHA384"
+            C_TLS1_2_ONLY[$i]="True"
+            C_SUBCA[$i]="$(x509Cert ecdsa-ca)"
+            C_CERT[$i]="$(x509Cert ecdsa-server)"
+            C_KEY[$i]="$(x509Key ecdsa-server)"
+            C_CLNT_CERT[$i]="$(x509Cert ecdsa-client)"
+            C_CLNT_KEY[$i]="$(x509Key ecdsa-client)"
+            i=$(($i+1))
+        fi
+
+        # NSS CA-cert DB
+        rlRun "mkdir nss-ca-db" 0 "Directory with just CA certificate"
+        rlRun "certutil -N --empty-password -d sql:./nss-ca-db" 0 "Create database for CA cert"
+        rlRun "certutil -A -d sql:./nss-ca-db -n ca -t 'cC,,' -a -i $(x509Cert ca)"
     rlPhaseEnd
 
-    rlPhaseStartTest "NSS server"
-        rlRun "mkdir nssdb/"
-        rlRun "certutil -N --empty-password -d sql:nssdb"
-        rlRun "certutil -A -d sql:nssdb -n ca -t 'cC,,' -a -i $(x509Cert rsa-ca)"
-        rlRun "pk12util -i $(x509Key --pkcs12 --with-cert rsa-server) -d sql:./nssdb -W ''"
+    for idx in ${!C_NAME[@]}; do
+        for proto in tls1_2 tls1_1; do
 
-        rlLogInfo "Test proper"
-        rlRun "$SERVER_UTIL -d sql:nssdb -p 4433 -V tls1.0: -H 1 -n rsa-server >server.log 2>server.err &"
-        nss_pid=$!
-        rlRun "rlWaitForSocket -p $nss_pid 4433"
-        for sett in "NORMAL" "NORMAL:+VERS-TLS1.2" "NORMAL:-VERS-TLS1.2"; do
-            rlRun -s "sleep 2 | gnutls-cli --priority '$sett' --resume --x509cafile $(x509Cert rsa-ca) --port 4433 localhost4"
-            rlAssertGrep "This is a resumed session" $rlRun_LOG
-            rlAssertNotGrep "failure" $rlRun_LOG -i
+            # skip tests of TLSv1.2 specific ciphers when testing TLSv1.1
+            if [[ $proto == "tls1_1" ]] && [[ ${C_TLS1_2_ONLY[$idx]} == "True" ]]; then
+                continue
+            fi
+
+            for sess_type in sessionID ticket; do
+            rlPhaseStartTest "NSS <-> GNUTLS [${C_NAME[$idx]}, $proto, $sess_type]"
+                # NSS server DB
+                rlRun "mkdir nssdb/"
+                rlRun "certutil -N --empty-password -d sql:./nssdb/"
+                rlRun "certutil -A -d sql:./nssdb/ -n ca -t 'cC,,' -a -i $(x509Cert ca)"
+                rlRun "certutil -A -d sql:./nssdb/ -n subca -t ',,' -a -i ${C_SUBCA[$idx]}"
+                rlRun "pk12util -i $(x509Key --pkcs12 --with-cert ${C_KEY[$idx]%%/*}) -d sql:./nssdb -W ''"
+
+                # NSS server setup
+                options=($SERVER_UTIL -d sql:nssdb -p 4433 -V tls1.0: -H 1)
+                options+=(-c :${C_NSS[$idx]})
+                if [[ ${C_KEY[$idx]} =~ 'ecdsa' ]]; then
+                    options+=(-e ${C_KEY[$idx]%%/*})
+                elif [[ ${C_KEY[$idx]} =~ 'dsa' ]]; then
+                    options+=(-S ${C_KEY[$idx]%%/*})
+                else
+                    options+=(-n ${C_KEY[$idx]%%/*})
+                fi
+                if [[ $sess_type == "ticket" ]]; then
+                    options+=(-u)
+                fi
+                rlRun "${options[*]} >server.log 2>server.err &"
+                nss_pid=$!
+                rlRun "rlWaitForSocket -p $nss_pid 4433"
+
+                # GNUTLS client setup
+                options=(gnutls-cli --resume --x509cafile $(x509Cert ca))
+                options+=(--port 4433)
+                if [[ $proto == "tls1_1" ]]; then
+                    options+=(--priority NORMAL:-VERS-TLS1.2)
+                else
+                    options+=(--priority NORMAL:+VERS-TLS1.2)
+                fi
+                rlRun -s "sleep 2 | ${options[*]} localhost"
+                rlAssertGrep "This is a resumed session" $rlRun_LOG
+                rlAssertNotGrep "failure" $rlRun_LOG -i
+                rlRun "kill $nss_pid" 0,1
+                rlRun "rlWait -s 9 $nss_pid" 143
+                if ! rlGetPhaseState; then
+                    rlRun "cat server.log"
+                    rlRun "cat server.err"
+                fi
+                rlRun "rm -fr nssdb"
+            rlPhaseEnd
+
+            rlPhaseStartTest "NSS <-> GNUTLS [${C_NAME[$idx]}, $proto, $sess_type, client auth]"
+                # NSS DB preparation
+                rlRun "mkdir nssdb/"
+                rlRun "certutil -N --empty-password -d sql:./nssdb/"
+                rlRun "certutil -A -d sql:./nssdb/ -n ca -t 'cCT,,' -a -i $(x509Cert ca)"
+                rlRun "certutil -A -d sql:./nssdb/ -n subca -t ',,' -a -i ${C_SUBCA[$idx]}"
+                rlRun "pk12util -i $(x509Key --pkcs12 --with-cert ${C_KEY[$idx]%%/*}) -d sql:./nssdb -W ''"
+
+                # NSS server setup
+                options=($SERVER_UTIL -d sql:nssdb -p 4433 -V tls1.0: -H 1 -rr)
+                options+=(-c :${C_NSS[$idx]})
+                if [[ ${C_KEY[$idx]} =~ 'ecdsa' ]]; then
+                    options+=(-e ${C_KEY[$idx]%%/*})
+                elif [[ ${C_KEY[$idx]} =~ 'dsa' ]]; then
+                    options+=(-S ${C_KEY[$idx]%%/*})
+                else
+                    options+=(-n ${C_KEY[$idx]%%/*})
+                fi
+                if [[ $sess_type == "ticket" ]]; then
+                    options+=(-u)
+                fi
+                rlRun "${options[*]} >server.log 2>server.err &"
+                nss_pid=$!
+                rlRun "rlWaitForSocket -p $nss_pid 4433"
+
+                # GNUTLS client setup
+                options=(gnutls-cli --resume)
+                options+=(--x509cafile '<(cat $(x509Cert ca) ${C_SUBCA[$idx]})')
+                options+=(--x509keyfile ${C_CLNT_KEY[$idx]})
+                options+=(--x509certfile ${C_CLNT_CERT[$idx]})
+                options+=(--port 4433)
+                if [[ $proto == "tls1_1" ]]; then
+                    options+=(--priority NORMAL:-VERS-TLS1.2)
+                else
+                    options+=(--priority NORMAL:+VERS-TLS1.2)
+                fi
+                rlRun -s "sleep 2 | ${options[*]} localhost"
+                rlAssertGrep "This is a resumed session" $rlRun_LOG
+                rlAssertNotGrep "failure" $rlRun_LOG -i
+                rlRun "kill $nss_pid" 0,1
+                rlRun "rlWait -s 9 $nss_pid" 143
+                if ! rlGetPhaseState; then
+                    rlRun "cat server.log"
+                    rlRun "cat server.err"
+                fi
+                rlRun "rm -fr nssdb"
+            rlPhaseEnd
+
+            rlPhaseStartTest "GNUTLS <-> NSS [${C_NAME[$idx]}, $proto, $sess_type]"
+                # GNUTLS server setup
+                options=(gnutls-serv --http --port 4433)
+                options+=(--priority NORMAL:+VERS-TLS1.2)
+                options+=(--x509keyfile ${C_KEY[$idx]})
+                options+=(--x509certfile '<(cat ${C_CERT[$idx]} ${C_SUBCA[$idx]})')
+                rlRun "${options[*]} >server.log 2>server.err &"
+                gnutls_pid=$!
+                rlRun "rlWaitForSocket -p $gnutls_pid 4433"
+
+                # NSS client setup
+                options=($CLIENT_UTIL -p 4433 -d sql:nss-ca-db -c 100 -P 20)
+                options+=(-C :${C_NSS[$idx]})
+                if [[ $proto == "tls1_2" ]]; then
+                    options+=(-V tls1.0:)
+                else
+                    options+=(-V tls1.0:tls1.1)
+                fi
+                if [[ $sess_type == "ticket" ]]; then
+                    options+=(-u)
+                fi
+                rlRun -s "${options[*]} localhost" 1
+                rlAssertGrep "80 cache hits" "$rlRun_LOG"
+                if [[ $sess_type == "ticket" ]]; then
+                    rlAssertGrep "80 stateless resumes" $rlRun_LOG
+                else
+                    rlAssertGrep "0 stateless resumes" $rlRun_LOG
+                fi
+                rlRun "kill $gnutls_pid" 0,1
+                rlRun "rlWait -s 9 $gnutls_pid" 143,1
+                if ! rlGetPhaseState; then
+                    rlRun "cat server.log"
+                    rlRun "cat server.err"
+                fi
+            rlPhaseEnd
+
+            # strsclnt can't handle client certificates (yet)
+            if false; then
+            rlPhaseStartTest "GNUTLS <-> NSS [${C_NAME[$idx]}, $proto, $sess_type, client auth]"
+                # NSS client DB
+                rlRun "mkdir nssdb/"
+                rlRun "certutil -N --empty-password -d sql:./nssdb"
+                rlRun "certutil -A -d sql:./nssdb -n ca -t 'cCT,,' -a -i $(x509Cert ca)"
+                rlRun "certutil -A -d sql:./nssdb -n subca -t ',,' -a -i ${C_SUBCA[$idx]}"
+                clnt_nickname="${C_CLNT_KEY[$idx]%%/*}"
+                rlRun "pk12util -i $(x509Key --pkcs12 --with-cert ${C_CLNT_KEY[$idx]%%/*}) -d sql:./nssdb -W ''"
+                rlRun "certutil -L -d sql:./nssdb"
+
+                # GNUTLS server setup
+                options=(gnutls-serv --http --port 4433)
+                options+=(--x509keyfile ${C_KEY[$idx]})
+                options+=(--x509cafile '<(cat $(x509Cert ca) ${C_SUBCA[$idx]})')
+                options+=(--x509certfile '<(cat ${C_CERT[$idx]} ${C_SUBCA[$idx]})')
+                options+=(--priority NORMAL:+VERS-TLS1.2)
+                options+=(--require-client-cert --verify-client-cert)
+                rlRun "${options[*]} >server.log 2>server.err &"
+                gnutls_pid=$!
+                rlRun "rlWaitForSocket -p $gnutls_pid 4433"
+
+                # NSS client setup
+                options=($CLIENT_UTIL -p 4433 -d sql:nssdb -c 100 -P 20)
+                options+=(-C :${C_NSS[$idx]} -n $clnt_nickname)
+                if [[ $proto == "tls1_2" ]]; then
+                    options+=(-V tls1.0:)
+                else
+                    options+=(-V tls1.0:tls1.1)
+                fi
+                if [[ $sess_type == "ticket" ]]; then
+                    options+=(-u)
+                fi
+                rlRun -s "${options[*]} localhost" 1
+                rlAssertGrep "80 cache hits" "$rlRun_LOG"
+                if [[ $sess_type == "ticket" ]]; then
+                    rlAssertGrep "80 stateless resumes" $rlRun_LOG
+                else
+                    rlAssertGrep "0 stateless resumes" $rlRun_LOG
+                fi
+                rlRun "kill $gnutls_pid" 0,1
+                rlRun "rlWait -s 9 $gnutls_pid" 143,1
+                if ! rlGetPhaseState; then
+                    rlRun "cat server.log"
+                    rlRun "cat server.err"
+                fi
+                rlRun "rm -fr nssdb"
+            rlPhaseEnd
+            fi
+            done
         done
-        rlRun "kill $nss_pid" 0,1
-        rlRun "rlWait -s 9 $nss_pid" 143
-    rlPhaseEnd
-
-    rlPhaseStartTest "GnuTLS server"
-        rlRun "gnutls-serv --priority NORMAL:+VERS-TLS1.2 --x509keyfile $(x509Key rsa-server) --x509certfile $(x509Cert rsa-server) --http --port 4433 >server.log 2>server.err &"
-        gnutls_pid=$!
-        rlRun "rlWaitForSocket -p $gnutls_pid 4433"
-        for sett in "tls1.1" "tls1.2"; do
-            rlRun -s "$CLIENT_UTIL -p 4433 -d sql:ca-db -c 100 -P 20 -V tls1.0:$sett localhost4" 1
-            rlAssertGrep "80 cache hits" "$rlRun_LOG"
-            rlAssertGrep "0 stateless resumes" $rlRun_LOG
-        done
-        rlRun "kill $gnutls_pid" 0,1
-        rlRun "rlWait -s 9 $gnutls_pid" 143,1
-    rlPhaseEnd
+    done
 
     rlPhaseStartCleanup
         rlRun "popd"


### PR DESCRIPTION
This PR extends the gnutls/resumption-with-NSS test with following:
* Various combinations of KEX, MAC and PRF algorithms
* Resumption with client authentication, session IDs and tickets

Known issues:
* `DHE-DSS` ciphersuites don't work when NSS is a server (see [PR#7](https://github.com/redhat-qe-security/interoperability/pull/7#issue-193376136))
* `strsclnt` can't handle client certificates (see [PR#7](https://github.com/redhat-qe-security/interoperability/pull/7#issue-193376136))
* segfault with `ECDSA` ciphersuites (see [PR#7](https://github.com/redhat-qe-security/interoperability/pull/7#issue-193376136))
* `TLS_DHE_DSS_WITH_AES_128_CBC_SHA` with TLS1.1 doesn't work with large DSA keys (see [PR#9](https://github.com/redhat-qe-security/interoperability/pull/9#issuecomment-282497817))

There's a one last issue on RHEL 7.4 (version nss-3.28.3-2.el7.x86_64) and I'm not sure if it's an expected behavior, as the process of fixing the ECDSA bugs was split into two phases (patching the segfault and patching the ticket support). When NSS is a server and the ticket extension is used, the handshake is unexpectedly terminated but the NSS server doesn't report any error:

```
::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
:: [   LOG    ] :: NSS <-> GNUTLS [TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, tls1_2, ticket]
::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
...
:: [  BEGIN   ] :: Running '/usr/lib64/nss/unsupported-tools/selfserv -d sql:nssdb -p 4433 -V tls1.0: -H 1 -c :C02C -e ecdsa-server -u -v >server.log 2>server.err &'
:: [   PASS   ] :: Command '/usr/lib64/nss/unsupported-tools/selfserv -d sql:nssdb -p 4433 -V tls1.0: -H 1 -c :C02C -e ecdsa-server -u -v >server.log 2>server.err &' (Expect$
d 0, got 0)
...
:: [  BEGIN   ] :: Running 'sleep 2 | gnutls-cli --resume --x509cafile ca/cert.pem --port 4433 --priority NORMAL:+VERS-TLS1.2 localhost'
Processed 1 CA certificate(s).
Resolving 'localhost'...
Connecting to '::1:4433'...
- Certificate type: X.509
- Got a certificate list of 3 certificates.
- Certificate[0] info:
 - subject `CN=localhost', issuer `CN=ECDSA CA', EC key 256 bits, signed using ECDSA-SHA256, activated `2017-03-11 23:07:04 UTC', expires `2018-03-11 23:07:04 UTC', SHA-1 fi$
gerprint `ae2b75c296839bd063ff94702b4083d112e97472'
        Public Key ID:
                3ea5f93984618857efdfc283485656f69cde7793
        Public key's random art:
                +--[  EC  256]----+
                |                 |
                |        .   o    |
                |     . o . o o . |
                |    . o o +   +  |
                |     . .S*.  . ..|
                |       .++o   .E+|
                |       o=o + .  +|
                |        .oo.= .  |
                |          o. o   |
                +-----------------+

- Certificate[1] info:
 - subject `CN=ECDSA CA', issuer `O=Example CA', EC key 256 bits, signed using RSA-SHA256, activated `2012-03-11 23:07:04 UTC', expires `2027-03-11 23:07:04 UTC', SHA-1 finge
rprint `79b61e397bff727e3c6831d94e6dcd4bbf96691e'
- Certificate[2] info:
 - subject `O=Example CA', issuer `O=Example CA', RSA key 2048 bits, signed using RSA-SHA256, activated `2012-03-11 23:07:03 UTC', expires `2027-03-11 23:07:03 UTC', SHA-1 fi
ngerprint `4e23d3f7057505257a40d0a68ce54860f81f9352'
- Status: The certificate is trusted. 
*** Fatal error: The TLS connection was non-properly terminated.
*** Handshake has failed
GnuTLS error: The TLS connection was non-properly terminated.
:: [   FAIL   ] :: Command 'sleep 2 | gnutls-cli --resume --x509cafile ca/cert.pem --port 4433 --priority NORMAL:+VERS-TLS1.2 localhost' (Expected 0, got 1)
:: [   FAIL   ] :: File '/var/tmp/rlRun_LOG.VyOTzFWM' should contain 'This is a resumed session' 
...
:: [  BEGIN   ] :: Running 'cat server.err'



selfserv: About to call accept.



selfserv: About to call accept.
selfserv: HDX PR_Read returned error 0:
Success
:: [   PASS   ] :: Command 'cat server.err' (Expected 0, got 0)

```