### PR TITLE
Re-enable gnutls/softhsm-integration

### DIFF
--- a/gnutls/Interoperability/softhsm-integration/Makefile
+++ b/gnutls/Interoperability/softhsm-integration/Makefile
@@ -57,5 +57,5 @@ $(METADATA): Makefile
 	@echo "License:         GPLv2+" >> $(METADATA)
 	@echo "Confidential:    yes" >> $(METADATA)
 	@echo "Destructive:     no" >> $(METADATA)
-	@echo "Releases:        -RHEL4 -RHELClient5 -RHELServer5 -RHEL6 -RHEL7" >> $(METADATA)
+	@echo "Releases:        -RHEL4 -RHELClient5 -RHELServer5 -RHEL6" >> $(METADATA)
 


### PR DESCRIPTION
As Docker finally has CentOS 7.3 images, we can re-enable this test. This fixes issue #6.