### PR TITLE
add missing openssl dependency

### DIFF
--- a/gnutls/Interoperability/renegotiation-with-NSS/Makefile
+++ b/gnutls/Interoperability/renegotiation-with-NSS/Makefile
@@ -53,7 +53,7 @@ $(METADATA): Makefile
 	@echo "Type:            Interoperability" >> $(METADATA)
 	@echo "TestTime:        10m" >> $(METADATA)
 	@echo "RunFor:          gnutls nss" >> $(METADATA)
-	@echo "Requires:        gnutls gnutls-utils nss nss-tools expect" >> $(METADATA)
+	@echo "Requires:        openssl gnutls gnutls-utils nss nss-tools expect" >> $(METADATA)
 	@echo "RhtsRequires:    library(openssl/certgen)" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv2" >> $(METADATA)


### PR DESCRIPTION
since the test uses openssl/certgen library, the openssl is used, and
thus needs to be part of the requirements for the test